### PR TITLE
perf: use v-if instead of v-show to improve the performance of large array

### DIFF
--- a/src/components/ArrayWrapper.vue
+++ b/src/components/ArrayWrapper.vue
@@ -33,7 +33,7 @@
     </template>
 
     <template v-else>
-      <span v-show="isExpanding" class="value">
+      <span v-if="isExpanding" class="value">
         <template v-for="key of keys" :key="key">
           <wrapper
             :name="key"


### PR DESCRIPTION
Use `v-show` will still render its children. If an object has a very large array(like 10000 length). Rendering all its elements will block the UI. But use `v-if` will ignore the rendering of children and won't have performance issues.